### PR TITLE
Add the eb script once per page

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,10 @@ export default class EventbritePopupCheckout extends React.Component {
     }
 
     const { ebScriptPath } = this.props;
+    
+    const existingEbScript = document.querySelector(`script[src="${ebScriptPath}"]`)
+    if (existingEbScript) {return;}
+
     const script = document.createElement('script');
     script.id = this.scriptId;
     script.async = true;


### PR DESCRIPTION
The current method allows duplicate `eb_widgets` scripts to be added if the checkout component is added multiple times on one page. (see below)
<img width="425" alt="Screen Shot 2019-07-21 at 10 42 00 AM" src="https://user-images.githubusercontent.com/8670798/61594767-7c4e4000-aba4-11e9-87c8-16800be14a5f.png">

This causes the checkout page to open multiple times. I added a check to see if the widget script already exists so that it's added only once per page.